### PR TITLE
Fix swap process to also include check that approved amount is enough

### DIFF
--- a/src/components/SwapButton.js
+++ b/src/components/SwapButton.js
@@ -9,8 +9,6 @@ import CheckIcon from '@material-ui/icons/Check';
 import SwapVertIcon from '@material-ui/icons/SwapVert';
 import Modal from '@material-ui/core/Modal';
 import Backdrop from '@material-ui/core/Backdrop';
-import InfoIcon from '@material-ui/icons/Info';
-import Tooltip from '@material-ui/core/Tooltip';
 
 import { withStyles, makeStyles } from '@material-ui/core/styles';
 
@@ -93,6 +91,12 @@ const LoadingIcon = withStyles((theme) => ({
 
 const renderButton = (swapState, approveSwap, swap) => {
     switch (swapState) {
+        case 'amountIsZero':
+            return <ColourButton
+                variant="contained"
+                color="secondary"
+                disabled="true"
+                size="large">Enter an amount</ColourButton>;
         case 'initial':
             return <ColourButton
                 onClick={() => approveSwap()}
@@ -153,11 +157,11 @@ export default function SwapButton(props) {
     return (
         <div>
             {renderButton(props.swapState, props.approveSwap, props.swap)}
-            {props.swapState === 'initial' &&
+            {/* {props.swapState === 'initial' &&
                 <Tooltip title="Approve input tokens for swapping. Will only send an Ethereum transaction if prior approval is insufficient." aria-label="Approve input tokens for swapping. Will only send an Ethereum transaction if prior approval is insufficient." placement="top" interactive>
                     <InfoIcon color="secondary" style={{ fontSize: 25, paddingLeft: 10 }} />
                 </Tooltip>
-            }
+            } */}
 
             <Modal
                 aria-labelledby="spring-modal-title"


### PR DESCRIPTION
Fix swap process to also include check that approved amount is enough without having to click "Approve Swap" again. Also added extra state for when amount is 0